### PR TITLE
add the xcb library to the linked libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS= -Wall -Wextra
 CFLAGS+= -O0 -ggdb
 CFLAGS+= -std=c99
 
-LDFLAGS= -lxcb-randr
+LDFLAGS= -lxcb-randr -lxcb
 
 all: xrandr-invert-colors.bin
 


### PR DESCRIPTION
should fix build problems on some systems; see issue #1.
